### PR TITLE
Fix version file URL property

### DIFF
--- a/Distribution/GameData/KerbalFlightIndicators/KerbalFlightIndicators.version
+++ b/Distribution/GameData/KerbalFlightIndicators/KerbalFlightIndicators.version
@@ -1,6 +1,6 @@
 {
     "NAME": "Kerbal Flight Indicators",
-    "URL": "https://github.com/PapaJoesSoup/KerbalFlightIndicators/GameData/KerbalFlightIndicators/KerbalFlightIndicators.version",
+    "URL": "https://github.com/PapaJoesSoup/KerbalFlightIndicators/raw/master/Distribution/GameData/KerbalFlightIndicators/KerbalFlightIndicators.version",
     "DOWNLOAD": "https://github.com/PapaJoesSoup/KerbalFlightIndicators/releases",
     "VERSION": {
         "MAJOR": 17


### PR DESCRIPTION
The URL property is supposed to contain a link to a raw version of the version file. Currently it's a 404, now it's fixed.